### PR TITLE
Add Role of Teacher to User

### DIFF
--- a/app/abilities/admins.rb
+++ b/app/abilities/admins.rb
@@ -1,3 +1,3 @@
 Canard::Abilities.for(:admin) do
-  can [:destroy], User
+  can :manage, :all
 end

--- a/app/abilities/teachers.rb
+++ b/app/abilities/teachers.rb
@@ -1,0 +1,3 @@
+Canard::Abilities.for(:teacher) do
+  includes_abilities_of :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
 
   # Permissions cascade/inherit through the roles listed below. The order of
   # this list is important, it should progress from least to most privelage
-  ROLES = [:admin].freeze
+  ROLES = [:admin, :teacher].freeze
   acts_as_user roles: ROLES
   roles ROLES
 

--- a/spec/abilities/teachers_spec.rb
+++ b/spec/abilities/teachers_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+require 'cancan/matchers'
+
+describe Canard::Abilities, '#teachers' do
+  let(:acting_teacher) { FactoryGirl.create(:user, :teacher) }
+  subject(:teacher_ability) { Ability.new(acting_teacher) }
+
+  describe 'on Teacher' do
+    let(:user) { FactoryGirl.create(:user) }
+
+    it { is_expected.to be_able_to(:manage, acting_teacher) }
+    it { is_expected.to_not be_able_to(:destroy, user) }
+  end
+  # on Teacher
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -13,6 +13,13 @@ FactoryGirl.define do
       last_name 'User'
       email 'admin@example.com'
     end
+
+    trait :teacher do
+      roles [:teacher]
+      first_name 'Abby'
+      last_name 'Teacher'
+      email 'teacher@exmaple.com'
+    end
   end
 end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe User, type: :model do
   describe 'constants' do
     context 'roles' do
       it 'has the admin role' do
-        expect(User::ROLES).to eq([:admin])
+        expect(User::ROLES).to eq([:admin, :teacher])
       end
     end
   end


### PR DESCRIPTION
Added the role of Teacher to users. Now a user can have no role, be an admin, be a teacher, or be both because of the Canard gem. As of now the teacher has no special abilities that are different from a normal User. I also edited the Admin to be able to manage everything as per what the next step will be.
